### PR TITLE
feat: skip duplicate highlights and auto-send cards on WiFi

### DIFF
--- a/AnkiFlashcards.koplugin/main.lua
+++ b/AnkiFlashcards.koplugin/main.lua
@@ -141,7 +141,18 @@ function AnkiFlashcards:init()
 
                 -- Save the selection as a document highlight before
                 -- closing (onClose clears the selection state).
-                rhi:saveHighlight()
+                -- Skip if a highlight already exists at the same position.
+                local already_highlighted = false
+                local anns = (ui.annotation and ui.annotation.annotations) or {}
+                for _, ann in ipairs(anns) do
+                    if ann.drawer and ann.pos0 == highlight_pos0 and ann.pos1 == highlight_pos1 then
+                        already_highlighted = true
+                        break
+                    end
+                end
+                if not already_highlighted then
+                    rhi:saveHighlight()
+                end
 
                 ui.highlight:onClose()
 
@@ -418,6 +429,38 @@ function AnkiFlashcards:init()
             end,
         }
     end)
+
+    -- ── Auto-Send on WiFi ────────────────────────────────────────────────────
+    -- Polls every 60s. When WiFi is on and auto_send_wifi is enabled,
+    -- flushes all unsent cards to AnkiConnect in the background.
+    local AUTO_SEND_INTERVAL = 60
+    local function auto_send_tick()
+        UIManager:scheduleIn(AUTO_SEND_INTERVAL, auto_send_tick)
+        local cfg = get_anki_config()
+        if not cfg.auto_send_wifi then return end
+        if not cfg.url or cfg.url == "" then return end
+        if not NetworkMgr:isOnline() then return end
+
+        local cards = CardStorage.load_cards()
+        local sent = 0
+        for _, card in ipairs(cards) do
+            if not card.sent_to_anki then
+                local ok = AnkiSync.send_card(cfg, card)
+                if ok then
+                    CardStorage.mark_sent(card.phrase)
+                    sent = sent + 1
+                end
+            end
+        end
+        if sent > 0 then
+            UIManager:show(Notification:new {
+                text    = sent .. _(" card(s) sent to Anki"),
+                timeout = 3,
+            })
+        end
+    end
+    -- First check after 30s to let KOReader settle on startup.
+    UIManager:scheduleIn(30, auto_send_tick)
 
 end
 

--- a/AnkiFlashcards.koplugin/settings_viewer.lua
+++ b/AnkiFlashcards.koplugin/settings_viewer.lua
@@ -117,6 +117,21 @@ function SettingsViewer.show(base_config, on_saved)
             }})
         end
 
+        -- Auto-Send on WiFi toggle (opt-in, disabled by default).
+        local auto_label = cfg.auto_send_wifi
+                           and _("Auto-Send on WiFi: ON (tap to disable)")
+                           or  _("Auto-Send on WiFi: OFF (tap to enable)")
+        table.insert(buttons, {{
+            text     = auto_label,
+            callback = function()
+                cfg.auto_send_wifi = not cfg.auto_send_wifi
+                CardStorage.save_anki_settings(cfg)
+                if on_saved then on_saved(cfg) end
+                UIManager:close(dlg)
+                show_settings_dialog()
+            end,
+        }})
+
         -- Test connection to configured AnkiConnect URL.
         table.insert(buttons, {{
             text     = _("Test Connection"),

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -64,28 +64,19 @@ Automatically route cards to a deck named after the current book: `English::<boo
 
 ---
 
-#### 5. Skip Duplicate Highlight on Card Creation
+#### ✅ 5. Skip Duplicate Highlight on Card Creation
 
-**Priority:** High — Low effort
+Before `rhi:saveHighlight()`, checks `ui.annotation.annotations` for an existing highlight at the same `pos0`/`pos1` — skips saving if already highlighted.
 
-When the user highlights a phrase that is already highlighted (e.g., re-reading a passage), `rhi:saveHighlight()` creates a duplicate highlight in the book. Before saving, check if a highlight already exists at the same position and skip the save if so.
-
-- Check `ui.annotation.annotations` for an existing highlight covering the same `pos0`/`pos1`
-- Only call `rhi:saveHighlight()` if no match is found
-- Avoids cluttering the book's highlight list with duplicates
+`main.lua` — loops through annotations before calling `rhi:saveHighlight()`.
 
 ---
 
-#### 6. Auto-Send on WiFi
+#### ✅ 6. Auto-Send on WiFi
 
-**Priority:** High — Medium effort
+Polls every 60s (first check after 30s). When WiFi is on and `auto_send_wifi` is enabled in settings, flushes all unsent cards to AnkiConnect and shows a notification with the count.
 
-When the Kobo connects to WiFi (e.g., for sync or browsing), silently flush all unsent locally-saved cards to AnkiConnect in the background.
-
-- Use `NetworkMgr` event/callback to detect WiFi becoming available
-- Trigger `AnkiSync.send_card` for each unsent card in `CardStorage.load_cards()`
-- Show a brief notification: "3 cards sent to Anki"
-- No user action required — cards appear in Anki automatically
+`main.lua` — `auto_send_tick()` scheduler in `init()`. `settings_viewer.lua` — tap-to-toggle button for the setting (disabled by default).
 
 ---
 


### PR DESCRIPTION
## Summary

- **Skip duplicate highlights (#5):** Before saving a highlight on card creation, checks `ui.annotation.annotations` for an existing highlight at the same `pos0`/`pos1` position — skips `rhi:saveHighlight()` if already highlighted
- **Auto-send on WiFi (#6):** Adds a recurring scheduler (60s interval, first check after 30s) that flushes all unsent cards to AnkiConnect when WiFi is available and the `auto_send_wifi` setting is enabled (opt-in, disabled by default)
- **Settings toggle:** New "Auto-Send on WiFi: ON/OFF" tap-to-toggle button in Anki Settings UI

Closes #5, closes #6

## Test plan

- [ ] Create a card for an already-highlighted phrase → no duplicate highlight created
- [ ] Create a card for a new phrase → highlight saved normally
- [ ] Settings → Auto-Send on WiFi toggle → shows ON/OFF, disabled by default
- [ ] Unsent cards + WiFi on + auto-send ON → cards sent within 60s with notification
- [ ] Auto-Send OFF → no auto-sending occurs
- [ ] `luac -p` passes on all modified files