### PR TITLE
feat: add Gemini as text generation provider

### DIFF
--- a/AnkiFlashcards.koplugin/card_generator.lua
+++ b/AnkiFlashcards.koplugin/card_generator.lua
@@ -1,5 +1,9 @@
--- AI flashcard generator — makes a single non-streaming call to Qwen via DashScope
--- and returns a structured card table.
+-- AI flashcard generator — makes a single non-streaming LLM call and
+-- returns a structured card table.
+--
+-- Supported text providers (config.text_provider):
+--   dashscope (default) — Qwen via DashScope (OpenAI-compatible)
+--   gemini              — Google Gemini Flash
 
 local https  = require("ssl.https")
 local http   = require("socket.http")
@@ -11,6 +15,93 @@ https.TIMEOUT = TIMEOUT
 http.TIMEOUT  = TIMEOUT
 
 local CardGenerator = {}
+
+-- ── Shared LLM helper ────────────────────────────────────────────────────
+
+local GEMINI_BASE_URL =
+    "https://generativelanguage.googleapis.com/v1beta/models/"
+
+-- Send a prompt to the configured LLM provider and return the text response.
+-- Returns (text, nil) or (nil, error_string).
+local function call_llm(config, prompt)
+    local provider = config.text_provider or "dashscope"
+    local response_body = {}
+
+    if provider == "gemini" then
+        local api_key = config.gemini_api_key
+        if not api_key or api_key == "" then
+            return nil, "Gemini API key not configured"
+        end
+        local model = config.gemini_text_model or "gemini-2.5-flash"
+        local url = GEMINI_BASE_URL .. model .. ":generateContent?key=" .. api_key
+        local body = json.encode({
+            contents = {{ parts = {{ text = prompt }} }},
+        })
+        https.TIMEOUT = TIMEOUT
+        local _, code = https.request {
+            url     = url,
+            method  = "POST",
+            headers = {
+                ["Content-Type"]  = "application/json",
+                ["Content-Length"] = tostring(#body),
+            },
+            source = ltn12.source.string(body),
+            sink   = ltn12.sink.table(response_body),
+        }
+        if tostring(code) ~= "200" then
+            local detail = table.concat(response_body):sub(1, 300)
+            return nil, "HTTP " .. tostring(code) .. ": " .. detail
+        end
+        local ok, data = pcall(json.decode, table.concat(response_body))
+        if not ok or not data then return nil, "JSON decode error" end
+        if data.candidates and data.candidates[1]
+           and data.candidates[1].content
+           and data.candidates[1].content.parts then
+            for _i, part in ipairs(data.candidates[1].content.parts) do
+                if part.text then return part.text end
+            end
+        end
+        return nil, "No text in Gemini response"
+    else
+        -- DashScope / OpenAI-compatible
+        local api_key = config.dashscope_api_key or config.api_key or ""
+        if api_key == "" then return nil, "API key not configured" end
+        local endpoint = config.provider
+        if not endpoint or endpoint == "" then
+            endpoint = "https://dashscope-intl.aliyuncs.com/compatible-mode/v1/chat/completions"
+        end
+        local body = json.encode({
+            model    = config.model or "qwen-plus",
+            messages = {{ role = "user", content = prompt }},
+        })
+        https.TIMEOUT = TIMEOUT
+        local _, code = https.request {
+            url     = endpoint,
+            method  = "POST",
+            headers = {
+                ["Content-Type"]  = "application/json",
+                ["Authorization"] = "Bearer " .. api_key,
+                ["Content-Length"] = tostring(#body),
+            },
+            source = ltn12.source.string(body),
+            sink   = ltn12.sink.table(response_body),
+        }
+        if tostring(code) ~= "200" then
+            local detail = table.concat(response_body):sub(1, 300)
+            return nil, "HTTP " .. tostring(code) .. ": " .. detail
+        end
+        local ok, decoded = pcall(json.decode, table.concat(response_body))
+        if ok and decoded
+           and decoded.choices
+           and decoded.choices[1]
+           and decoded.choices[1].message then
+            return decoded.choices[1].message.content
+        end
+        return nil, "Unexpected API response format"
+    end
+end
+
+-- ── Prompt templates ──────────────────────────────────────────────────────
 
 -- Single-call prompt: returns raw JSON, no markdown fences.
 local PROMPT_TEMPLATE = [[You are an English flashcard generator for an advanced learner reading "{title}" by "{author}".
@@ -30,6 +121,18 @@ Return ONLY a valid JSON object, no other text:
   "text": "<example sentence at B2–C1 level: use simple grammar and everyday vocabulary — the highlighted phrase must be the ONLY challenging word; create a FRESH scenario completely unrelated to the book — do NOT borrow wording, subjects, or settings from the Context; invent new characters and a new situation; conjugate the phrase NATURALLY to fit the sentence grammar (correct tense, person, number); {{c1::...}} must wrap ONLY the phrase as it naturally appears in this sentence — it MAY differ from the canonical form above (e.g. canonical 'batter someone' might appear as {{c1::battered}} in past tense); do NOT force the neutralized/canonical form into the sentence; no extra words around it inside the cloze>",
   "image_prompt": "<vivid scene description from the example sentence above, suitable for anime-style illustration, widescreen 16:9, no text or words in the scene>"
 }]]
+
+-- Sentence-only regeneration prompt: returns text (cloze) + image_prompt.
+local TEXT_REGEN_PROMPT = [[You are an English flashcard generator.
+Phrase: "{phrase}"
+
+Return ONLY a valid JSON object, no other text:
+{
+  "text": "<example sentence at B2–C1 level: use simple grammar and everyday vocabulary — the phrase must be the ONLY challenging word; create a FRESH scenario — invent new characters and a new situation; conjugate the phrase NATURALLY to fit the sentence grammar (correct tense, person, number); {{c1::...}} must wrap ONLY the phrase as it naturally appears in this sentence — it MAY differ from the canonical form above (e.g. canonical 'batter someone' might appear as {{c1::battered}} in past tense); do NOT force the neutralized/canonical form into the sentence; no extra words around it inside the cloze>",
+  "image_prompt": "<vivid scene description from the example sentence above, suitable for anime-style illustration, widescreen 16:9, no text or words in the scene>"
+}]]
+
+-- ── Helpers ───────────────────────────────────────────────────────────────
 
 local function escape_for_prompt(s)
     if not s then return "" end
@@ -54,15 +157,12 @@ local function parse_response(raw)
     return card
 end
 
+-- ── Public API ────────────────────────────────────────────────────────────
+
 -- Generate a flashcard. Returns (card_table, nil) or (nil, error_string).
 -- card_table fields: phrase, ipa, definition, synonyms, text
 -- source/book_title/book_author are added by main.lua.
 function CardGenerator.generate(config, phrase, context, title, author)
-    local api_key = config and (config.dashscope_api_key or config.api_key) or ""
-    if api_key == "" then
-        return nil, "API key not configured"
-    end
-
     -- Use function-form replacement to prevent % in values being treated as
     -- gsub pattern specials (e.g. book text containing "100%").
     local t = escape_for_prompt(title   or "Unknown")
@@ -75,210 +175,51 @@ function CardGenerator.generate(config, phrase, context, title, author)
         :gsub("{phrase}",  function() return p end)
         :gsub("{context}", function() return c end)
 
-    local request_body = json.encode({
-        model    = config.model or "qwen-plus",
-        messages = {{ role = "user", content = prompt }},
-    })
-
-    local headers = {
-        ["Content-Type"]  = "application/json",
-        ["Authorization"] = "Bearer " .. api_key,
-    }
-
-    local provider = config.provider
-    if not provider or provider == "" then
-        provider = "https://dashscope-intl.aliyuncs.com/compatible-mode/v1/chat/completions"
-    end
-
-    local response_body = {}
-    local ok, code = https.request {
-        url     = provider,
-        method  = "POST",
-        headers = headers,
-        source  = ltn12.source.string(request_body),
-        sink    = ltn12.sink.table(response_body),
-    }
-
-    if tostring(code) ~= "200" then
-        local err_body = table.concat(response_body)
-        return nil, "HTTP " .. tostring(code) .. ": " .. err_body:sub(1, 300)
-    end
-
-    local raw_text
-    local ok2, decoded = pcall(json.decode, table.concat(response_body))
-    if ok2 and decoded
-       and decoded.choices
-       and decoded.choices[1]
-       and decoded.choices[1].message then
-        raw_text = decoded.choices[1].message.content
-    end
-
-    if not raw_text then
-        return nil, "Unexpected API response format"
-    end
-
+    local raw_text, err = call_llm(config, prompt)
+    if not raw_text then return nil, err end
     return parse_response(raw_text)
 end
-
--- Sentence-only regeneration prompt: returns text (cloze) + image_prompt.
-local TEXT_REGEN_PROMPT = [[You are an English flashcard generator.
-Phrase: "{phrase}"
-
-Return ONLY a valid JSON object, no other text:
-{
-  "text": "<example sentence at B2–C1 level: use simple grammar and everyday vocabulary — the phrase must be the ONLY challenging word; create a FRESH scenario — invent new characters and a new situation; conjugate the phrase NATURALLY to fit the sentence grammar (correct tense, person, number); {{c1::...}} must wrap ONLY the phrase as it naturally appears in this sentence — it MAY differ from the canonical form above (e.g. canonical 'batter someone' might appear as {{c1::battered}} in past tense); do NOT force the neutralized/canonical form into the sentence; no extra words around it inside the cloze>",
-  "image_prompt": "<vivid scene description from the example sentence above, suitable for anime-style illustration, widescreen 16:9, no text or words in the scene>"
-}]]
 
 -- Regenerate only the example sentence and image prompt for a phrase.
 -- Returns (text, image_prompt) or (nil, error_string).
 function CardGenerator.generate_text(config, phrase)
-    local api_key = config and (config.dashscope_api_key or config.api_key) or ""
-    if api_key == "" then return nil, "API key not configured" end
-
     local p = escape_for_prompt(phrase or "")
     local prompt = TEXT_REGEN_PROMPT
         :gsub("{phrase}", function() return p end)
 
-    local request_body = json.encode({
-        model    = config.model or "qwen-plus",
-        messages = {{ role = "user", content = prompt }},
-    })
-
-    local headers = {
-        ["Content-Type"]  = "application/json",
-        ["Authorization"] = "Bearer " .. api_key,
-    }
-
-    local provider = config.provider
-    if not provider or provider == "" then
-        provider = "https://dashscope-intl.aliyuncs.com/compatible-mode/v1/chat/completions"
-    end
-
-    local response_body = {}
-    local ok, code = https.request {
-        url     = provider,
-        method  = "POST",
-        headers = headers,
-        source  = ltn12.source.string(request_body),
-        sink    = ltn12.sink.table(response_body),
-    }
-
-    if tostring(code) ~= "200" then
-        return nil, "HTTP " .. tostring(code)
-    end
-
-    local ok2, decoded = pcall(json.decode, table.concat(response_body))
-    if ok2 and decoded
-       and decoded.choices
-       and decoded.choices[1]
-       and decoded.choices[1].message then
-        local card = parse_response(decoded.choices[1].message.content)
-        if card then
-            return card.text, card.image_prompt
-        end
+    local raw_text, err = call_llm(config, prompt)
+    if not raw_text then return nil, err end
+    local card = parse_response(raw_text)
+    if card then
+        return card.text, card.image_prompt
     end
     return nil, "Unexpected API response"
 end
 
 -- Generate IPA only for a given phrase. Returns (ipa_string, nil) or (nil, error).
 function CardGenerator.generate_ipa(config, phrase)
-    local api_key = config and (config.dashscope_api_key or config.api_key) or ""
-    if api_key == "" then return nil, "API key not configured" end
-
     local prompt = 'Return ONLY the American English IPA for: "'
                    .. (phrase or "")
                    .. '"\nReply with just the IPA notation, nothing else. Example: /ɪɡˈzæmpəl/'
 
-    local request_body = json.encode({
-        model    = config.model or "qwen-plus",
-        messages = {{ role = "user", content = prompt }},
-    })
-
-    local headers = {
-        ["Content-Type"]  = "application/json",
-        ["Authorization"] = "Bearer " .. api_key,
-    }
-
-    local provider = config.provider
-    if not provider or provider == "" then
-        provider = "https://dashscope-intl.aliyuncs.com/compatible-mode/v1/chat/completions"
-    end
-
-    local response_body = {}
-    local ok, code = https.request {
-        url     = provider,
-        method  = "POST",
-        headers = headers,
-        source  = ltn12.source.string(request_body),
-        sink    = ltn12.sink.table(response_body),
-    }
-
-    if tostring(code) ~= "200" then
-        return nil, "HTTP " .. tostring(code)
-    end
-
-    local ok2, decoded = pcall(json.decode, table.concat(response_body))
-    if ok2 and decoded
-       and decoded.choices
-       and decoded.choices[1]
-       and decoded.choices[1].message then
-        local ipa = decoded.choices[1].message.content
-        if ipa then
-            return ipa:match("^%s*(.-)%s*$")  -- trim whitespace
-        end
-    end
-    return nil, "Unexpected API response"
+    local raw_text, err = call_llm(config, prompt)
+    if not raw_text then return nil, err end
+    return raw_text:match("^%s*(.-)%s*$")  -- trim whitespace
 end
 
 -- Quick lookup: IPA + short definition only (for purple highlight tap).
 -- Returns ({ipa, definition}, nil) or (nil, error_string).
 function CardGenerator.generate_quick_lookup(config, phrase)
-    local api_key = config and (config.dashscope_api_key or config.api_key) or ""
-    if api_key == "" then return nil, "API key not configured" end
-
     local p = escape_for_prompt(phrase or "")
     local prompt = 'You are an English dictionary. Return ONLY valid JSON for: "' .. p .. '"\n'
                 .. '{"ipa": "<American English IPA, e.g. /ɪɡˈzæmpəl/>", '
                 .. '"definition": "<simple, clear definition in everyday English, max 15 words>"}'
 
-    local request_body = json.encode({
-        model    = config.model or "qwen-plus",
-        messages = {{ role = "user", content = prompt }},
-    })
-
-    local headers = {
-        ["Content-Type"]  = "application/json",
-        ["Authorization"] = "Bearer " .. api_key,
-    }
-
-    local provider = config.provider
-    if not provider or provider == "" then
-        provider = "https://dashscope-intl.aliyuncs.com/compatible-mode/v1/chat/completions"
-    end
-
-    local response_body = {}
-    local ok, code = https.request {
-        url     = provider,
-        method  = "POST",
-        headers = headers,
-        source  = ltn12.source.string(request_body),
-        sink    = ltn12.sink.table(response_body),
-    }
-
-    if tostring(code) ~= "200" then
-        return nil, "HTTP " .. tostring(code)
-    end
-
-    local ok2, decoded = pcall(json.decode, table.concat(response_body))
-    if ok2 and decoded
-       and decoded.choices
-       and decoded.choices[1]
-       and decoded.choices[1].message then
-        local result = parse_response(decoded.choices[1].message.content)
-        if result and result.ipa and result.definition then
-            return result
-        end
+    local raw_text, err = call_llm(config, prompt)
+    if not raw_text then return nil, err end
+    local result = parse_response(raw_text)
+    if result and result.ipa and result.definition then
+        return result
     end
     return nil, "Unexpected API response"
 end

--- a/AnkiFlashcards.koplugin/card_manager.lua
+++ b/AnkiFlashcards.koplugin/card_manager.lua
@@ -116,6 +116,7 @@ function CardManager.show_manage(base_config, opts)
                     for k, v in pairs(new_cfg) do anki_config[k] = v end
                     -- Promote plugin-level settings to the top-level config.
                     for _, key in ipairs({
+                        "text_provider",
                         "image_provider",
                         "dashscope_api_key",
                         "gemini_api_key",

--- a/AnkiFlashcards.koplugin/configuration.lua.sample
+++ b/AnkiFlashcards.koplugin/configuration.lua.sample
@@ -1,20 +1,26 @@
 local CONFIGURATION = {
-    -- DashScope (Qwen) — used for both card text generation and image generation.
+    -- DashScope (Qwen) — card text and image generation (default).
     -- Get your key at: https://dashscope-intl.console.aliyun.com/
     dashscope_api_key = "YOUR_DASHSCOPE_API_KEY",
     provider          = "https://dashscope-intl.aliyuncs.com/compatible-mode/v1/chat/completions",
     model             = "qwen-plus",
 
+    -- ── Gemini (Google) — alternative for text and image generation ──────
+    -- Get your key at: https://aistudio.google.com/apikey
+    -- Billing must be enabled for image generation.
+    gemini_api_key = "YOUR_GEMINI_API_KEY",
+
+    -- ── Text provider ─────────────────────────────────────────────────────
+    -- Which service to use for card text generation (definitions, IPA, etc.).
+    -- Options: "dashscope" (default), "gemini"
+    text_provider = "dashscope",
+
     -- ── Image provider ────────────────────────────────────────────────────
     -- Which service to use for image generation.
     -- Options: "dashscope" (default, requires dashscope_api_key),
-    --          "gemini" (free tier: 500 imgs/day, requires gemini_api_key),
+    --          "gemini" (requires gemini_api_key + billing),
     --          "pollinations" (free, no API key, but unreliable)
     image_provider = "dashscope",
-
-    -- ── Gemini (Google) — used for image generation only ─────────────────
-    -- Free tier: ~500 images/day. Get your key at: https://aistudio.google.com/apikey
-    gemini_api_key = "YOUR_GEMINI_API_KEY",
 
     -- ── ElevenLabs TTS (optional — generates audio for Anki cards) ─────────
     elevenlabs_api_key  = "YOUR_ELEVENLABS_API_KEY",

--- a/AnkiFlashcards.koplugin/main.lua
+++ b/AnkiFlashcards.koplugin/main.lua
@@ -36,6 +36,7 @@ do
         CONFIGURATION.anki = saved_anki
         -- Promote plugin-level settings from saved anki settings to top level.
         for _, key in ipairs({
+            "text_provider",
             "image_provider",
             "dashscope_api_key",
             "gemini_api_key",

--- a/AnkiFlashcards.koplugin/settings_viewer.lua
+++ b/AnkiFlashcards.koplugin/settings_viewer.lua
@@ -119,6 +119,26 @@ function SettingsViewer.show(base_config, on_saved)
             }})
         end
 
+        -- Text provider toggle.
+        local TEXT_PROVIDERS = { "dashscope", "gemini" }
+        local cur_text = cfg.text_provider or "dashscope"
+        local text_label = _("Text Provider: ") .. cur_text
+        table.insert(buttons, {{
+            text     = text_label,
+            callback = function()
+                local idx = 1
+                for i, p in ipairs(TEXT_PROVIDERS) do
+                    if p == cur_text then idx = i; break end
+                end
+                local next_tp = TEXT_PROVIDERS[(idx % #TEXT_PROVIDERS) + 1]
+                cfg.text_provider = next_tp
+                CardStorage.save_anki_settings(cfg)
+                if on_saved then on_saved(cfg) end
+                UIManager:close(dlg)
+                show_settings_dialog()
+            end,
+        }})
+
         -- Image provider toggle.
         local IMAGE_PROVIDERS = { "dashscope", "gemini", "pollinations" }
         local cur_provider = cfg.image_provider or "dashscope"

--- a/README.md
+++ b/README.md
@@ -31,9 +31,13 @@ Developed and tested on a **Kobo Libra Colour** and a **Kindle** running KOReade
 - *(Optional)* A [Gemini API key](https://aistudio.google.com/apikey) for image generation via Google Gemini Flash
 - *(Optional)* An [ElevenLabs API key](https://elevenlabs.io/) for TTS audio on cards
 
-## AI Provider: Qwen via DashScope
+## AI Providers
 
-This plugin uses **Qwen** (by Alibaba Cloud) for all AI generation — card text, IPA, and images.
+The plugin supports multiple AI providers for both text and image generation. You can mix providers — e.g. use Gemini for text and DashScope for images.
+
+### Qwen via DashScope (default)
+
+DashScope is the default provider for both text and image generation.
 
 To get an API key:
 
@@ -63,6 +67,16 @@ The plugin uses two DashScope APIs: **qwen-plus** for text and **qwen-image-plus
 | 300 | ~$9.00 |
 
 > Prices based on [DashScope international pricing](https://www.alibabacloud.com/help/en/model-studio/model-pricing) (Singapore region): qwen-plus at $0.40/$1.20 per 1M input/output tokens, qwen-image-plus at $0.03/image.
+
+### Google Gemini Flash (alternative)
+
+[Gemini 2.5 Flash](https://ai.google.dev/gemini-api) can be used for both text and image generation. A single API key covers both. Text generation on the free tier is generous (~500 RPD); image generation requires billing.
+
+To set up:
+
+1. Get an API key at [Google AI Studio](https://aistudio.google.com/apikey)
+2. On the Kobo, go to **Anki Settings → Gemini API Key** and paste your key
+3. Switch **Text Provider** to `gemini` and/or **Image Provider** to `gemini`
 
 ## Installation
 
@@ -151,22 +165,15 @@ ElevenLabs charges per character. A typical card generates ~100–200 characters
 
 > The free tier includes 10,000 characters/month (~50–100 cards).
 
-## Image Generation Providers
+## Provider Summary
 
-The plugin supports multiple image generation providers. You can switch providers on-device via **Anki Settings → Image Provider**.
+Switch providers on-device via **Anki Settings** — Text Provider and Image Provider can be set independently.
 
-| Provider | Cost | API Key | Notes |
-|----------|------|---------|-------|
-| **DashScope** (default) | ~$0.03/image | Required | Qwen image-plus, async polling |
-| **Gemini Flash** | $0.039/image | Required | Google Gemini 2.5 Flash, fast and reliable |
-| **Pollinations** | Free | None | No API key needed, but may be unreliable |
-
-### Setting up Gemini
-
-1. Get a free API key at [Google AI Studio](https://aistudio.google.com/apikey)
-2. Enable billing on your Google Cloud project (required for image generation, even at low usage)
-3. On the Kobo, go to **Anki Settings → Gemini API Key** and paste your key
-4. Switch **Image Provider** to `gemini`
+| Provider | Text | Image | Cost (text) | Cost (image) | API Key |
+|----------|:----:|:-----:|-------------|-------------|---------|
+| **DashScope** (default) | yes | yes | ~free | ~$0.03/image | Required |
+| **Gemini Flash** | yes | yes | ~free (free tier) | $0.039/image | Required |
+| **Pollinations** | - | yes | - | Free | None |
 
 ### Setting up Pollinations
 
@@ -174,4 +181,4 @@ No setup needed — just switch **Image Provider** to `pollinations`. No API key
 
 ## Configuration via Settings UI
 
-You can set the Anki URL, deck, tags, image provider, API keys, and TTS settings directly on the device without editing `configuration.lua`: long-press any text → **Anki Manage** → **Anki Settings**.
+You can set the Anki URL, deck, tags, text/image providers, API keys, and TTS settings directly on the device without editing `configuration.lua`: long-press any text → **Anki Manage** → **Anki Settings**.


### PR DESCRIPTION
## Summary

- Refactored `card_generator.lua` to extract a shared `call_llm()` helper, eliminating ~80 lines of duplicated HTTP code across 4 functions
- Added **Google Gemini 2.5 Flash** as an alternative text generation provider (definitions, IPA, synonyms, cloze sentences)
- Text and image providers can be configured independently — e.g. Gemini for text + DashScope for images
- Added `text_provider` toggle to on-device settings UI (cycles: dashscope → gemini)
- Updated configuration sample and README with provider documentation

### Provider comparison

| Provider | Text | Image | Cost (text) | Cost (image) | API Key |
|----------|:----:|:-----:|-------------|-------------|---------|
| DashScope (default) | yes | yes | ~free | ~$0.03/image | Required |
| Gemini Flash | yes | yes | ~free (free tier) | $0.039/image | Required |
| Pollinations | - | yes | - | Free | None |

Closes #7

## Test plan

- [ ] Set `text_provider` to `gemini`, generate a card, verify definition/IPA/synonyms/cloze are correct
- [ ] Set `text_provider` to `dashscope` (default), verify existing behavior preserved
- [ ] Verify text regen, IPA regen, and quick lookup all work with both providers
- [ ] Verify text and image providers can be set independently (e.g. gemini text + dashscope image)
- [ ] Verify settings toggle cycles correctly and persists across restarts
- [ ] Validate Lua syntax with `luac -p` on all modified files