### PR TITLE
fix: use hidden directory for generated images

### DIFF
--- a/AnkiFlashcards.koplugin/image_generator.lua
+++ b/AnkiFlashcards.koplugin/image_generator.lua
@@ -18,7 +18,7 @@ local json        = require("json")
 local mime        = require("mime")
 local DataStorage = require("datastorage")
 
-local IMAGE_DIR = DataStorage:getDataDir() .. "/anki_images"
+local IMAGE_DIR = DataStorage:getDataDir() .. "/.anki_images"
 
 local ImageGenerator = {}
 


### PR DESCRIPTION
## Summary
- Rename image storage from `anki_images/` to `.anki_images/` (hidden directory)
- Prevents Kobo's Nickel firmware from indexing generated flashcard images as books in its library

## Test plan
- [x] Generate a new flashcard with an image — verify it's saved to `.anki_images/`
- [x] Connect Kobo via USB and confirm Nickel does not list images as books
- [x] Existing images in `anki_images/` should be manually moved to `.anki_images/`