### PR TITLE
feat: overlay phrase text on flashcard image (back side)

### DIFF
--- a/AnkiFlashcards.koplugin/card_viewer.lua
+++ b/AnkiFlashcards.koplugin/card_viewer.lua
@@ -258,6 +258,7 @@ function CardViewer:init()
                 height       = max_h,
                 scale_factor = 0,
             }
+            img:getSize()  -- trigger lazy rendering so _bb is available
             img_h = max_h
         end
         -- Overlay phrase text on the image buffer (back side).


### PR DESCRIPTION
## Summary
- Renders the phrase as **uppercase white bold text with black outline** directly on the flashcard image when showing the back side
- Removes the separate phrase text widget when an image is present, freeing vertical space for definition/cloze content
- Falls back to the existing blue text widget when no image is available
- Tap-to-zoom still shows the original image (no overlay)
- Font size scales to ~10% of image height, auto-shrinks if text exceeds image width

## Test plan
- [ ] Generate a card with an image → back side shows phrase overlaid on the image bottom
- [ ] Tap the image → zoomed view shows original image without overlay
- [ ] Generate a card where image fails to load → phrase shows as blue text widget (fallback)
- [ ] Test with a long phrase → font auto-shrinks to fit within image width

Closes #44