### PR TITLE
fix: improve Pollinations error handling with user-friendly messages

### DIFF
--- a/AnkiFlashcards.koplugin/image_generator.lua
+++ b/AnkiFlashcards.koplugin/image_generator.lua
@@ -281,6 +281,9 @@ if d then d:write(c) d:close() end
     return true
 end
 
+local POLLINATIONS_USER_HINT =
+    "Pollinations is unreliable. Consider switching to another image provider in Anki Settings."
+
 local function pollinations_generate(config, image_prompt, phrase, on_success, on_error)
     local UIManager = require("ui/uimanager")
     local save_path = make_save_path(phrase)
@@ -313,7 +316,7 @@ local function pollinations_generate(config, image_prompt, phrase, on_success, o
     ))
 
     local attempts = 0
-    local max_attempts = 24  -- 24 × 3s = 72s
+    local max_attempts = 10  -- 10 × 3s = 30s (fail fast — service is unreliable)
     local function poll()
         attempts = attempts + 1
 
@@ -336,10 +339,10 @@ local function pollinations_generate(config, image_prompt, phrase, on_success, o
                     end
                 end
                 os.remove(save_path)
-                if on_error then on_error("Pollinations returned empty image") end
+                if on_error then on_error("Pollinations returned empty image. " .. POLLINATIONS_USER_HINT) end
             else
                 os.remove(save_path)
-                if on_error then on_error("Pollinations HTTP " .. (code or "error")) end
+                if on_error then on_error("Pollinations error (HTTP " .. (code or "?") .. "). " .. POLLINATIONS_USER_HINT) end
             end
             return
         end
@@ -347,7 +350,7 @@ local function pollinations_generate(config, image_prompt, phrase, on_success, o
         if attempts >= max_attempts then
             os.remove(done_file)
             os.remove(save_path)
-            if on_error then on_error("Image generation timed out") end
+            if on_error then on_error("Pollinations timed out. " .. POLLINATIONS_USER_HINT) end
             return
         end
 


### PR DESCRIPTION
## Summary
- Reduced polling timeout from 72s to 30s — fail fast since the service is unreliable
- All error paths (HTTP errors, empty images, timeouts) now show a clear message: *"Pollinations is unreliable. Consider switching to another image provider in Anki Settings."*

## Changes
| File | Change |
|------|--------|
| `image_generator.lua` | Reduced `max_attempts` from 24 to 10, added `POLLINATIONS_USER_HINT` to all error messages |

## Test plan
- [ ] Set `image_provider` to `pollinations`, generate a card — if it fails, verify the user-friendly hint appears
- [ ] If Pollinations happens to work, verify image still downloads correctly
- [ ] `luac -p AnkiFlashcards.koplugin/*.lua` — no syntax errors

Closes #38