### PR TITLE
fix: default AnkiVocab URL to https://api.ankivocab.com

### DIFF
--- a/AnkiFlashcards.koplugin/audio_generator.lua
+++ b/AnkiFlashcards.koplugin/audio_generator.lua
@@ -11,7 +11,8 @@ local BASE_URL      = "https://api.elevenlabs.io/v1/text-to-speech/"
 local DEFAULT_VOICE = "JBFqnCBsd6RMkjVDRZzb"  -- Rachel
 local DEFAULT_MODEL = "eleven_multilingual_v2"
 local OUTPUT_FORMAT = "mp3_22050_32"
-local TIMEOUT       = 10
+local TIMEOUT              = 10
+local ANKIVOCAB_DEFAULT_URL = "https://api.ankivocab.com"
 
 local AudioGenerator = {}
 
@@ -126,9 +127,10 @@ function AudioGenerator.poll_ankivocab_async(config, word, on_success, on_error)
     local UIManager = require("ui/uimanager")
 
     local api_url = config.ankivocab_url
+    if not api_url or api_url == "" then api_url = ANKIVOCAB_DEFAULT_URL end
     local api_key = config.ankivocab_api_key
-    if not api_url or api_url == "" or not api_key or api_key == "" then
-        if on_error then on_error("AnkiVocab not configured") end
+    if not api_key or api_key == "" then
+        if on_error then on_error("AnkiVocab API key not configured") end
         return
     end
     api_url = api_url:gsub("/$", "")

--- a/AnkiFlashcards.koplugin/card_generator.lua
+++ b/AnkiFlashcards.koplugin/card_generator.lua
@@ -17,6 +17,8 @@ local TIMEOUT = 20
 https.TIMEOUT = TIMEOUT
 http.TIMEOUT  = TIMEOUT
 
+local ANKIVOCAB_DEFAULT_URL = "https://api.ankivocab.com"
+
 local CardGenerator = {}
 
 -- ── Shared LLM helper ────────────────────────────────────────────────────
@@ -174,7 +176,7 @@ end
 local function generate_ankivocab(config, phrase, context, title, author)
     local api_url = config.ankivocab_url
     if not api_url or api_url == "" then
-        return nil, "AnkiVocab URL not configured"
+        api_url = ANKIVOCAB_DEFAULT_URL
     end
     local api_key = config.ankivocab_api_key
     if not api_key or api_key == "" then

--- a/AnkiFlashcards.koplugin/configuration.lua.sample
+++ b/AnkiFlashcards.koplugin/configuration.lua.sample
@@ -45,6 +45,10 @@ local CONFIGURATION = {
     elevenlabs_voice_id = "JBFqnCBsd6RMkjVDRZzb",  -- Rachel (default)
     tts_enabled         = false,
 
+    -- ── AnkiVocab Gateway (optional) ─────────────────────────────────────────
+    -- URL defaults to https://api.ankivocab.com — only override for dev/testing.
+    -- ankivocab_url = "http://localhost:8000",
+
     -- ── Anki integration ────────────────────────────────────────────────────
     -- Requires AnkiConnect add-on running on the same network as your Kobo.
     -- Use the LAN IP of the device running Anki — not "localhost".

--- a/AnkiFlashcards.koplugin/image_generator.lua
+++ b/AnkiFlashcards.koplugin/image_generator.lua
@@ -798,11 +798,14 @@ end
 -- in the initial card generation response.  Returns (url, nil) or (nil, err).
 -- IMPORTANT: this runs inside UIManager callbacks, so the HTTP timeout must be
 -- short to avoid freezing the e-ink UI.
+local ANKIVOCAB_DEFAULT_URL = "https://api.ankivocab.com"
+
 local function ankivocab_poll_image_url(config, word)
     local api_url = config.ankivocab_url
+    if not api_url or api_url == "" then api_url = ANKIVOCAB_DEFAULT_URL end
     local api_key = config.ankivocab_api_key
-    if not api_url or api_url == "" or not api_key or api_key == "" then
-        return nil, "AnkiVocab not configured"
+    if not api_key or api_key == "" then
+        return nil, "AnkiVocab API key not configured"
     end
     api_url = api_url:gsub("/$", "")
     local endpoint = api_url .. "/v1/cards/generate"

--- a/AnkiFlashcards.koplugin/main.lua
+++ b/AnkiFlashcards.koplugin/main.lua
@@ -47,7 +47,6 @@ do
             "openrouter_api_key",
             "openrouter_model",
             "elevenlabs_api_key",
-            "ankivocab_url",
             "ankivocab_api_key",
         }) do
             if saved_anki[key] and saved_anki[key] ~= "" then

--- a/AnkiFlashcards.koplugin/settings_viewer.lua
+++ b/AnkiFlashcards.koplugin/settings_viewer.lua
@@ -286,10 +286,11 @@ function SettingsViewer.show(base_config, on_saved)
 
         local function check_credits()
             local api_url = cfg.ankivocab_url
+            if not api_url or api_url == "" then api_url = "https://api.ankivocab.com" end
             local api_key = cfg.ankivocab_api_key
-            if not api_url or api_url == "" or not api_key or api_key == "" then
+            if not api_key or api_key == "" then
                 UIManager:show(Notification:new {
-                    text = _("Set AnkiVocab URL and API key first"),
+                    text = _("Set AnkiVocab API key first"),
                     timeout = 3,
                 })
                 return
@@ -333,12 +334,6 @@ function SettingsViewer.show(base_config, on_saved)
         sub_dlg = ButtonDialog:new {
             title   = _("AnkiVocab Gateway"),
             buttons = {
-                {{ text = _("URL: ") .. short("ankivocab_url"),
-                   callback = function()
-                       UIManager:close(sub_dlg)
-                       edit_field("AnkiVocab URL", "ankivocab_url",
-                                 "https://api.ankivocab.com", show_ankivocab_gateway)
-                   end }},
                 {{ text = _("API Key: ") .. mask_key(cfg.ankivocab_api_key or ""),
                    callback = function()
                        UIManager:close(sub_dlg)


### PR DESCRIPTION
## Summary

- Default AnkiVocab URL to `https://api.ankivocab.com` in code — users only need to enter their API key
- Remove URL button from the settings UI (one less field to configure)
- URL can still be overridden via `configuration.lua` for dev/testing

## Test plan

- [x] `luac -p` syntax check passes on all files
- [ ] Generate card with AnkiVocab provider without setting URL — should use default
- [ ] Check Credits button works without URL set
- [ ] Override URL in configuration.lua — should use the override