### PR TITLE
fix: correct default AnkiVocab URL to https://ankivocab.com

### DIFF
--- a/AnkiFlashcards.koplugin/audio_generator.lua
+++ b/AnkiFlashcards.koplugin/audio_generator.lua
@@ -12,7 +12,7 @@ local DEFAULT_VOICE = "JBFqnCBsd6RMkjVDRZzb"  -- Rachel
 local DEFAULT_MODEL = "eleven_multilingual_v2"
 local OUTPUT_FORMAT = "mp3_22050_32"
 local TIMEOUT              = 10
-local ANKIVOCAB_DEFAULT_URL = "https://api.ankivocab.com"
+local ANKIVOCAB_DEFAULT_URL = "https://ankivocab.com"
 
 local AudioGenerator = {}
 

--- a/AnkiFlashcards.koplugin/card_generator.lua
+++ b/AnkiFlashcards.koplugin/card_generator.lua
@@ -17,7 +17,7 @@ local TIMEOUT = 20
 https.TIMEOUT = TIMEOUT
 http.TIMEOUT  = TIMEOUT
 
-local ANKIVOCAB_DEFAULT_URL = "https://api.ankivocab.com"
+local ANKIVOCAB_DEFAULT_URL = "https://ankivocab.com"
 
 local CardGenerator = {}
 

--- a/AnkiFlashcards.koplugin/configuration.lua.sample
+++ b/AnkiFlashcards.koplugin/configuration.lua.sample
@@ -46,7 +46,7 @@ local CONFIGURATION = {
     tts_enabled         = false,
 
     -- ── AnkiVocab Gateway (optional) ─────────────────────────────────────────
-    -- URL defaults to https://api.ankivocab.com — only override for dev/testing.
+    -- URL defaults to https://ankivocab.com — only override for dev/testing.
     -- ankivocab_url = "http://localhost:8000",
 
     -- ── Anki integration ────────────────────────────────────────────────────

--- a/AnkiFlashcards.koplugin/image_generator.lua
+++ b/AnkiFlashcards.koplugin/image_generator.lua
@@ -798,7 +798,7 @@ end
 -- in the initial card generation response.  Returns (url, nil) or (nil, err).
 -- IMPORTANT: this runs inside UIManager callbacks, so the HTTP timeout must be
 -- short to avoid freezing the e-ink UI.
-local ANKIVOCAB_DEFAULT_URL = "https://api.ankivocab.com"
+local ANKIVOCAB_DEFAULT_URL = "https://ankivocab.com"
 
 local function ankivocab_poll_image_url(config, word)
     local api_url = config.ankivocab_url

--- a/AnkiFlashcards.koplugin/settings_viewer.lua
+++ b/AnkiFlashcards.koplugin/settings_viewer.lua
@@ -286,7 +286,7 @@ function SettingsViewer.show(base_config, on_saved)
 
         local function check_credits()
             local api_url = cfg.ankivocab_url
-            if not api_url or api_url == "" then api_url = "https://api.ankivocab.com" end
+            if not api_url or api_url == "" then api_url = "https://ankivocab.com" end
             local api_key = cfg.ankivocab_api_key
             if not api_key or api_key == "" then
                 UIManager:show(Notification:new {


### PR DESCRIPTION
## Summary

\`api.ankivocab.com\` doesn't resolve — the API is at \`ankivocab.com\`. Fixes the default URL in all 5 files.

## Test plan

- [x] \`curl https://ankivocab.com/v1/auth/me\` returns 401 (reachable)
- [x] \`curl https://api.ankivocab.com/...\` fails (host not found)
- [x] \`luac -p\` syntax check passes