### PR TITLE
feat: add model selection to AI Providers settings UI

### DIFF
--- a/AnkiFlashcards.koplugin/anki_sync.lua
+++ b/AnkiFlashcards.koplugin/anki_sync.lua
@@ -98,7 +98,7 @@ function AnkiSync.send_card(config, card, tts_config)
         return nil, "Anki URL not configured"
     end
 
-    local model = config.model or "Vocabulary"
+    local model = config.anki_model or config.model or "Vocabulary"
 
     local fields = {
         ["Phrase"]     = card.phrase     or "",

--- a/AnkiFlashcards.koplugin/card_manager.lua
+++ b/AnkiFlashcards.koplugin/card_manager.lua
@@ -37,7 +37,18 @@ local function effective_config(base)
     end
     local saved = CardStorage.load_anki_settings()
     if saved then
-        for k, v in pairs(saved) do cfg[k] = v end
+        for k, v in pairs(saved) do
+            if k == "anki_model" then
+                cfg.model = v
+            elseif k == "model" and (v == "Vocabulary" or v == "English") then
+                cfg.model = v
+            elseif k ~= "model" and k ~= "image_model"
+               and k ~= "gemini_text_model" and k ~= "gemini_image_model"
+               and k ~= "openai_model" and k ~= "openai_image_model"
+               and k ~= "openrouter_model" and k ~= "openrouter_image_model" then
+                cfg[k] = v
+            end
+        end
     end
     return cfg
 end
@@ -125,11 +136,18 @@ function CardManager.show_manage(base_config, opts)
                         "target_language",
                         "text_provider",
                         "image_provider",
+                        "model",
+                        "image_model",
+                        "gemini_text_model",
+                        "gemini_image_model",
+                        "openai_model",
+                        "openai_image_model",
                         "dashscope_api_key",
                         "gemini_api_key",
                         "openai_api_key",
                         "openrouter_api_key",
                         "openrouter_model",
+                        "openrouter_image_model",
                         "elevenlabs_api_key",
                     }) do
                         if new_cfg[key] then

--- a/AnkiFlashcards.koplugin/configuration.lua.sample
+++ b/AnkiFlashcards.koplugin/configuration.lua.sample
@@ -3,16 +3,21 @@ local CONFIGURATION = {
     -- Get your key at: https://dashscope-intl.console.aliyun.com/
     dashscope_api_key = "YOUR_DASHSCOPE_API_KEY",
     provider          = "https://dashscope-intl.aliyuncs.com/compatible-mode/v1/chat/completions",
-    model             = "qwen-plus",
+    model             = "qwen-plus",        -- text model
+    image_model       = "qwen-image-plus",  -- image model
 
     -- ── Gemini (Google) — alternative for text and image generation ──────
     -- Get your key at: https://aistudio.google.com/apikey
     -- Billing must be enabled for image generation.
-    gemini_api_key = "YOUR_GEMINI_API_KEY",
+    gemini_api_key     = "YOUR_GEMINI_API_KEY",
+    gemini_text_model  = "gemini-2.5-flash",
+    gemini_image_model = "gemini-2.5-flash-image",
 
     -- ── OpenAI — GPT-4o-mini for text, GPT Image / DALL-E for images ──────
     -- Get your key at: https://platform.openai.com/api-keys
-    openai_api_key = "YOUR_OPENAI_API_KEY",
+    openai_api_key     = "YOUR_OPENAI_API_KEY",
+    openai_model       = "gpt-4o-mini",
+    openai_image_model = "gpt-image-1",
 
     -- ── OpenRouter — access to hundreds of models via one API key ─────────
     -- Get your key at: https://openrouter.ai/keys

--- a/AnkiFlashcards.koplugin/image_generator.lua
+++ b/AnkiFlashcards.koplugin/image_generator.lua
@@ -104,7 +104,6 @@ end
 local DASHSCOPE_BASE_URL  = "https://dashscope-intl.aliyuncs.com/api/v1"
 local DASHSCOPE_CREATE_URL = DASHSCOPE_BASE_URL .. "/services/aigc/text2image/image-synthesis"
 local DASHSCOPE_TASK_URL   = DASHSCOPE_BASE_URL .. "/tasks/"
-local DASHSCOPE_MODEL      = "qwen-image-plus"
 
 local NEGATIVE_PROMPT =
     "text, words, letters, numbers, watermark, signature, blurry, " ..
@@ -143,13 +142,13 @@ local function dashscope_https_request(method, url, api_key, body, extra_headers
     return data
 end
 
-local function dashscope_create_task(api_key, image_prompt)
+local function dashscope_create_task(config, api_key, image_prompt)
     local prompt =
         "Modern anime-style illustration: " .. (image_prompt or "") ..
         ". Widescreen 16:9 composition, vibrant colors, clean lines, " ..
         "professional quality. No text, words, letters or numbers anywhere."
     local body = json.encode({
-        model  = DASHSCOPE_MODEL,
+        model  = config.image_model or "qwen-image-plus",
         input  = {
             prompt          = prompt,
             negative_prompt = NEGATIVE_PROMPT,
@@ -230,7 +229,7 @@ local function dashscope_generate(config, image_prompt, phrase, on_success, on_e
     end
 
     local function try_create()
-        local task_id, err = dashscope_create_task(api_key, image_prompt)
+        local task_id, err = dashscope_create_task(config, api_key, image_prompt)
         if not task_id then
             if err == "RATE_LIMITED" then
                 UIManager:scheduleIn(15, try_create)
@@ -364,9 +363,7 @@ end
 
 -- ── Gemini Flash provider ──────────────────────────────────────────────────
 
-local GEMINI_URL =
-    "https://generativelanguage.googleapis.com/v1beta/models/"
-    .. "gemini-2.5-flash-image:generateContent"
+local GEMINI_BASE_URL = "https://generativelanguage.googleapis.com/v1beta/models/"
 
 local function gemini_generate(config, image_prompt, phrase, on_success, on_error)
     local api_key = config and config.gemini_api_key
@@ -394,10 +391,11 @@ local function gemini_generate(config, image_prompt, phrase, on_success, on_erro
             },
         })
 
+        local model = config.gemini_image_model or "gemini-2.5-flash-image"
         local response = {}
         https.TIMEOUT = 30
         local _, code = https.request {
-            url     = GEMINI_URL .. "?key=" .. api_key,
+            url     = GEMINI_BASE_URL .. model .. ":generateContent?key=" .. api_key,
             method  = "POST",
             headers = {
                 ["Content-Type"]   = "application/json",

--- a/AnkiFlashcards.koplugin/main.lua
+++ b/AnkiFlashcards.koplugin/main.lua
@@ -41,16 +41,25 @@ do
             "target_language",
             "text_provider",
             "image_provider",
+            "model",
+            "image_model",
+            "gemini_text_model",
+            "gemini_image_model",
+            "openai_model",
+            "openai_image_model",
             "dashscope_api_key",
             "gemini_api_key",
             "openai_api_key",
             "openrouter_api_key",
             "openrouter_model",
+            "openrouter_image_model",
             "elevenlabs_api_key",
             "ankivocab_api_key",
         }) do
             if saved_anki[key] and saved_anki[key] ~= "" then
-                CONFIGURATION[key] = saved_anki[key]
+                if key ~= "model" or (saved_anki[key] ~= "Vocabulary" and saved_anki[key] ~= "English") then
+                    CONFIGURATION[key] = saved_anki[key]
+                end
             end
         end
     end
@@ -114,7 +123,18 @@ local function get_anki_config()
     end
     local fresh = CardStorage.load_anki_settings()
     if fresh then
-        for k, v in pairs(fresh) do cfg[k] = v end
+        for k, v in pairs(fresh) do
+            if k == "anki_model" then
+                cfg.model = v
+            elseif k == "model" and (v == "Vocabulary" or v == "English") then
+                cfg.model = v
+            elseif k ~= "model" and k ~= "image_model"
+               and k ~= "gemini_text_model" and k ~= "gemini_image_model"
+               and k ~= "openai_model" and k ~= "openai_image_model"
+               and k ~= "openrouter_model" and k ~= "openrouter_image_model" then
+                cfg[k] = v
+            end
+        end
     end
     return cfg
 end

--- a/AnkiFlashcards.koplugin/settings_viewer.lua
+++ b/AnkiFlashcards.koplugin/settings_viewer.lua
@@ -23,12 +23,24 @@ function SettingsViewer.show(base_config, on_saved)
             if k ~= "anki" then cfg[k] = v end
         end
         if type(base_config.anki) == "table" then
-            for k, v in pairs(base_config.anki) do cfg[k] = v end
+            for k, v in pairs(base_config.anki) do
+                if k == "model" then
+                    cfg.anki_model = v
+                else
+                    cfg[k] = v
+                end
+            end
         end
     end
     local saved = CardStorage.load_anki_settings()
     if saved then
         for k, v in pairs(saved) do cfg[k] = v end
+        -- Older settings used cfg.model for the Anki note type.  Keep those
+        -- users working while freeing cfg.model for the DashScope text model.
+        if not saved.anki_model and (saved.model == "Vocabulary" or saved.model == "English") then
+            cfg.anki_model = saved.model
+            cfg.model = base_config and base_config.model or "qwen-plus"
+        end
     end
 
     -- ── Shared helpers ───────────────────────────────────────────────────
@@ -139,10 +151,10 @@ function SettingsViewer.show(base_config, on_saved)
         local buttons = {}
 
         table.insert(buttons, {{
-            text     = _("Note type: ") .. (cfg.model or "Vocabulary"),
+            text     = _("Note type: ") .. (cfg.anki_model or "Vocabulary"),
             callback = function()
                 UIManager:close(sub_dlg)
-                edit_field("Note Type", "model", "Vocabulary",
+                edit_field("Note Type", "anki_model", "Vocabulary",
                           show_anki_connection)
             end,
         }})
@@ -217,6 +229,24 @@ function SettingsViewer.show(base_config, on_saved)
         local TEXT_PROVIDERS  = { "dashscope", "gemini", "openai", "openrouter", "ankivocab" }
         local IMAGE_PROVIDERS = { "dashscope", "gemini", "openai", "openrouter", "pollinations", "ankivocab" }
 
+        local TEXT_MODEL_FIELDS = {
+            dashscope  = { key = "model",             label = "Text model",  hint = "qwen-plus" },
+            gemini     = { key = "gemini_text_model", label = "Text model",  hint = "gemini-2.5-flash" },
+            openai     = { key = "openai_model",      label = "Text model",  hint = "gpt-4o-mini" },
+            openrouter = { key = "openrouter_model",  label = "Text model",  hint = "deepseek/deepseek-v3:free" },
+        }
+
+        local IMAGE_MODEL_FIELDS = {
+            dashscope  = { key = "image_model",              label = "Image model", hint = "qwen-image-plus" },
+            gemini     = { key = "gemini_image_model",       label = "Image model", hint = "gemini-2.5-flash-image" },
+            openai     = { key = "openai_image_model",       label = "Image model", hint = "gpt-image-1" },
+            openrouter = {
+                key   = "openrouter_image_model",
+                label = "Image model",
+                hint  = "google/gemini-3.1-flash-image-preview",
+            },
+        }
+
         local function cycle(key, options)
             local cur = cfg[key] or options[1]
             local idx = 1
@@ -229,16 +259,43 @@ function SettingsViewer.show(base_config, on_saved)
             show_ai_providers()
         end
 
+        local buttons = {
+            {{ text = _("Text: ") .. (cfg.text_provider or "dashscope"),
+               callback = function() cycle("text_provider", TEXT_PROVIDERS) end }},
+            {{ text = _("Image: ") .. (cfg.image_provider or "dashscope"),
+               callback = function() cycle("image_provider", IMAGE_PROVIDERS) end }},
+        }
+
+        local text_model = TEXT_MODEL_FIELDS[cfg.text_provider or "dashscope"]
+        if text_model then
+            table.insert(buttons, {{
+                text = _(text_model.label .. ": ") .. short(text_model.key, 42),
+                callback = function()
+                    UIManager:close(sub_dlg)
+                    edit_field(text_model.label, text_model.key, text_model.hint,
+                              show_ai_providers)
+                end,
+            }})
+        end
+
+        local image_model = IMAGE_MODEL_FIELDS[cfg.image_provider or "dashscope"]
+        if image_model then
+            table.insert(buttons, {{
+                text = _(image_model.label .. ": ") .. short(image_model.key, 42),
+                callback = function()
+                    UIManager:close(sub_dlg)
+                    edit_field(image_model.label, image_model.key, image_model.hint,
+                              show_ai_providers)
+                end,
+            }})
+        end
+
+        table.insert(buttons, {{ text = _("Back"),
+           callback = function() UIManager:close(sub_dlg); show_main() end }})
+
         sub_dlg = ButtonDialog:new {
             title   = _("AI Providers"),
-            buttons = {
-                {{ text = _("Text: ") .. (cfg.text_provider or "dashscope"),
-                   callback = function() cycle("text_provider", TEXT_PROVIDERS) end }},
-                {{ text = _("Image: ") .. (cfg.image_provider or "dashscope"),
-                   callback = function() cycle("image_provider", IMAGE_PROVIDERS) end }},
-                {{ text = _("Back"),
-                   callback = function() UIManager:close(sub_dlg); show_main() end }},
-            },
+            buttons = buttons,
         }
         UIManager:show(sub_dlg)
     end

--- a/README.md
+++ b/README.md
@@ -138,7 +138,8 @@ Supported languages include: English, Spanish, French, German, Italian, Portugue
    local CONFIGURATION = {
        dashscope_api_key = "YOUR_DASHSCOPE_API_KEY",
        provider          = "https://dashscope-intl.aliyuncs.com/compatible-mode/v1/chat/completions",
-       model             = "qwen-plus",
+       model             = "qwen-plus",        -- text model
+       image_model       = "qwen-image-plus",  -- image model
 
        -- Optional: ElevenLabs TTS audio
        elevenlabs_api_key  = "YOUR_ELEVENLABS_API_KEY",
@@ -235,7 +236,7 @@ No setup needed — just switch **Image Provider** to `pollinations`. No API key
 
 ## Configuration via Settings UI
 
-You can set the Anki URL, deck, tags, text/image providers, API keys, and TTS settings directly on the device without editing `configuration.lua`: long-press any text → **Anki Manage** → **Anki Settings**.
+You can set the Anki URL, deck, tags, text/image providers, provider model names, API keys, and TTS settings directly on the device without editing `configuration.lua`: long-press any text → **Anki Manage** → **Anki Settings**.
 
 ## License
 

--- a/tests/test_issue42_model_settings.py
+++ b/tests/test_issue42_model_settings.py
@@ -1,0 +1,62 @@
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PLUGIN = ROOT / "AnkiFlashcards.koplugin"
+
+
+def read(name: str) -> str:
+    return (PLUGIN / name).read_text(encoding="utf-8")
+
+
+def test_ai_provider_settings_expose_provider_model_fields():
+    settings = read("settings_viewer.lua")
+
+    for key in [
+        "model",
+        "image_model",
+        "gemini_text_model",
+        "gemini_image_model",
+        "openai_model",
+        "openai_image_model",
+        "openrouter_model",
+        "openrouter_image_model",
+    ]:
+        assert re.search(rf'key\s*=\s*"{key}"', settings)
+
+    assert "Text model" in settings
+    assert "Image model" in settings
+
+
+def test_image_generators_use_configurable_model_names():
+    image_generator = read("image_generator.lua")
+
+    assert 'config.image_model or "qwen-image-plus"' in image_generator
+    assert 'config.gemini_image_model or "gemini-2.5-flash-image"' in image_generator
+    assert 'config.openai_image_model or "gpt-image-1"' in image_generator
+    assert 'config.openrouter_image_model or "google/gemini-3.1-flash-image-preview"' in image_generator
+
+
+def test_configuration_sample_documents_model_keys():
+    sample = read("configuration.lua.sample")
+
+    for key in [
+        "model",
+        "image_model",
+        "gemini_text_model",
+        "gemini_image_model",
+        "openai_model",
+        "openai_image_model",
+        "openrouter_model",
+        "openrouter_image_model",
+    ]:
+        assert key in sample
+
+
+def test_legacy_anki_model_does_not_override_text_model():
+    settings = read("settings_viewer.lua")
+    main = read("main.lua")
+
+    assert "cfg.anki_model = saved.model" in settings
+    assert 'cfg.model = base_config and base_config.model or "qwen-plus"' in settings
+    assert 'key ~= "model" or (saved_anki[key] ~= "Vocabulary"' in main


### PR DESCRIPTION
## Summary
- Add contextual text/image model fields to the AI Providers settings submenu
- Make DashScope and Gemini image generation use configurable model keys instead of hardcoded names
- Preserve legacy Anki note-type settings by separating old `model` values into `anki_model`
- Document model keys in the sample config and README

## Test Plan
- `pytest -q`
- `git diff --check`
- `luac -p` on touched Lua files
- `luajit -b` parse checks on touched Lua files

Closes #42