### PR TITLE
ci: pin Claude Code action and model

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,15 +26,16 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 1
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@70a6e5256e9e2366a1ed5c041904a982ba3a328f # v1.0.135
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: "--model claude-sonnet-4-6"
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |


### PR DESCRIPTION
## Summary
- Pin `anthropics/claude-code-action` to the latest resolved SHA (`v1.0.135`)
- Pin `actions/checkout` to the latest resolved v6 SHA in Claude workflows
- Explicitly run Claude Code with the latest Sonnet model via `claude_args: --model claude-sonnet-4-6`
- Preserve existing allowed tools, MCP config, prompts, and workflow behavior

## Validation
- Parsed changed workflow YAML files with Ruby/Psych
- Ran `git diff --check`
- Verified changed Claude workflows no longer use floating Claude Code Action refs (`v1`, `beta`, `eap`, `v1.0.0`) or stale Claude model IDs
